### PR TITLE
Fix Database connection and insertion issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "when": "3.6.4",
     "socket.io": "1.2.1",
     "lodash": "2.4.1",
-    "mongodb": "2.0.0",
+    "mongodb": "2.0.1",
     "gulp": "3.8.10",
     "gulp-jshint": "1.9.0",
     "gulp-sass": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "when": "3.6.4",
     "socket.io": "1.2.1",
     "lodash": "2.4.1",
-    "mongodb": "~1.4.29",
+    "mongodb": "2.0.0",
     "gulp": "3.8.10",
     "gulp-jshint": "1.9.0",
     "gulp-sass": "1.2.4",
@@ -23,6 +23,7 @@
     "gulp-sourcemaps": "1.3.0",
     "jshint-stylish": "1.0.0",
     "event-stream": "3.2.1",
-    "del": "1.1.1"
+    "del": "1.1.1",
+    "bson": "0.2.18"
   }
 }

--- a/server/data/mongo.plan.js
+++ b/server/data/mongo.plan.js
@@ -35,17 +35,15 @@ module.exports = function (run) {
     return run(function (db) {
       var deferred = w.defer();
 
-      collection(db)
-        .find({ _id: new ObjectID(id) })
-        .next(function (err, doc) {
-          if (doc) {
-            return deferred.resolve(doc);
-          } else if (err) {
-            return deferred.reject(err);
-          }else {
-            return deferred.reject(new Error("Plan not found for ID " + id));
-          }
-        });
+      collection(db).findOne({ _id: new ObjectID(id) }, function (err, doc) {
+        if (err) {
+          return deferred.reject(err);
+        } else if (_.isEmpty(doc)) {
+          return deferred.reject(new Error("Plan not found for ID " + id));
+        } else {
+          return deferred.resolve(doc);
+        }
+      });
 
       return deferred.promise;
     });

--- a/server/data/mongo.plan.js
+++ b/server/data/mongo.plan.js
@@ -3,9 +3,8 @@ var w               = require('when'),
     // Useful for casting plan IDs to MongoIds for queries
     ObjectID        = require('mongodb').ObjectID,
     // The name of the collection/table this module represents
-    COLLECTION_NAME = 'plans',
     // Generates the Mongo collection for Plans
-    collection      = function (db) { return db.collection(COLLECTION_NAME); };
+    collection      = function (db) { return db.collection('plans'); };
 
 /**
 * Mongo/Plan Module
@@ -36,15 +35,17 @@ module.exports = function (run) {
     return run(function (db) {
       var deferred = w.defer();
 
-      collection(db).findOne({ _id: new ObjectID(id) }, function (err, doc) {
-        if (err) {
-          return deferred.reject(err);
-        } else if (_.isEmpty(doc)) {
-          return deferred.reject(new Error("Plan not found for ID " + id));
-        } else {
-          return deferred.resolve(doc);
-        }
-      });
+      collection(db)
+        .find({ _id: new ObjectID(id) })
+        .next(function (err, doc) {
+          if (doc) {
+            return deferred.resolve(doc);
+          } else if (err) {
+            return deferred.reject(err);
+          }else {
+            return deferred.reject(new Error("Plan not found for ID " + id));
+          }
+        });
 
       return deferred.promise;
     });
@@ -66,9 +67,9 @@ module.exports = function (run) {
 
       collection(db).insert(plan, function (err) {
         if (err) {
-          return deferred.reject(err);
+          deferred.reject(err);
         } else {
-          return deferred.resolve(plan);
+          deferred.resolve(plan);
         }
       });
 

--- a/server/data/plan.js
+++ b/server/data/plan.js
@@ -59,8 +59,8 @@ module.exports = exports = {};
 *
 * @return A promise for the resulting object, or an error if the creation fails
 */
-exports.create = function () { 
-  return Plan.insert(planTemplate); 
+exports.create = function () {
+  return Plan.insert(_.clone(planTemplate));
 };
 
 /**

--- a/server/data/plan.js
+++ b/server/data/plan.js
@@ -59,7 +59,9 @@ module.exports = exports = {};
 *
 * @return A promise for the resulting object, or an error if the creation fails
 */
-exports.create = function () { return Plan.insert(planTemplate); };
+exports.create = function () { 
+  return Plan.insert(planTemplate); 
+};
 
 /**
 * @function get


### PR DESCRIPTION
Solves 2 issues at the database level:
- A new connection was opened for each request, rather than sharing from one connection pool
- The plan template was mutated on the first "plan" creation, thereby causing subsequent creation requests to use the same `_id` object--violating the unique ID constraint

In addition to fixing these issues, we upgrade to the newest version of the native Mongo driver and clean up the `findOne` code.
